### PR TITLE
RDS：DBインスタンスを削除／リストアアクションリリースに向けて、必要な権限を追加しました

### DIFF
--- a/rds-policy.json
+++ b/rds-policy.json
@@ -8,10 +8,21 @@
         "rds:CopyDBSnapshot",
         "rds:CreateDBSnapshot",
         "rds:DeleteDBSnapshot",
+        "rds:DeleteDBInstance",
         "rds:DescribeDBInstances",
         "rds:DescribeDBSnapshots",
+        "rds:DescribeDBInstances",
+        "rds:DescribeDBParameterGroups",
+        "rds:DescribeDBParameters",
+        "rds:DescribeDBSecurityGroups",
+        "rds:DescribeDBSubnetGroups",
+        "rds:DescribeOptionGroups",
+        "rds:DescribeOrderableDBInstanceOptions",
         "rds:ListTagsForResource",
-        "rds:RemoveTagsFromResource"
+        "rds:RemoveTagsFromResource",
+        "rds:ModifyDBInstance",
+        "rds:RebootDBInstance",
+        "rds:RestoreDBInstanceFromDBSnapshot"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
下記機能を利用するにあたり必要な権限を追加しました。

- RDS:DBインスタンスを削除
- RDS:DBスナップショットからリストア