### PR TITLE
IAMに不足している権限があったので追加しました

### DIFF
--- a/iam-policy.json
+++ b/iam-policy.json
@@ -19,6 +19,7 @@
                 "iam:ListPolicies",
                 "iam:ListPolicyVersions",
                 "iam:ListRoles",
+                "iam:ListUsers",
                 "iam:SetDefaultPolicyVersion",
                 "config:DeleteConfigRule",
                 "config:DescribeDeliveryChannels",


### PR DESCRIPTION
IAMユーザーにポリシーをアタッチ/デタッチアクションで、権限が不足しているようなので追加しました。

関連: https://serverworks.slack.com/archives/C0296520C/p1521427840000099