### PR TITLE
構成レビュー機能の利用に今後必要になるポリシーを追加

### DIFF
--- a/iam-policy.json
+++ b/iam-policy.json
@@ -21,6 +21,7 @@
                 "iam:ListRoles",
                 "iam:ListUsers",
                 "iam:SetDefaultPolicyVersion",
+                "iam:UpdateAssumeRolePolicy",
                 "config:DeleteConfigRule",
                 "config:DescribeDeliveryChannels",
                 "config:PutDeliveryChannel",


### PR DESCRIPTION
構成レビュー機能のバックエンド拡張に伴い、今後必要なIAM権限が増えるため、権限を追加しました。
