### PR TITLE
WorkSpacesで利用を許可するActionを追加した

### DIFF
--- a/workspaces-policy.json
+++ b/workspaces-policy.json
@@ -4,7 +4,11 @@
         {
             "Effect": "Allow",
             "Action": [
+                "workspaces:DescribeTags",
+                "workspaces:DescribeWorkspaceBundles",
+                "workspaces:DescribeWorkspaceDirectories",
                 "workspaces:DescribeWorkspaces",
+                "workspaces:DescribeWorkspacesConnectionStatus",
                 "workspaces:TerminateWorkspaces"
             ],
             "Resource": [


### PR DESCRIPTION
WorkSpacesリスト機能において利用される以下のWorkSpaces APIを許可するActionに追加します。

- describe_tags
- describe_workspace_bundles
- describe_workspace_directories
- describe_workspaces
- describe_workspaces_connection_status
