### PR TITLE
古い SQS トリガーから新しい SQS トリガーの変換に必要なアクションが不足していたので、不足分を追加しました

### DIFF
--- a/sqs-policy.json
+++ b/sqs-policy.json
@@ -6,6 +6,7 @@
       "Action": [
         "sqs:AddPermission",
         "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes",
         "sqs:GetQueueUrl",
         "sqs:ListQueues",
         "sqs:ReceiveMessage",


### PR DESCRIPTION
古い SQS トリガーから新しい SQS トリガーの変換に必要なアクションが不足していたので、不足分を追加しました。