### PR TITLE
IAMロール認証を使うAWSアカウント削除時に必要となるIAMポリシーを追加した

### DIFF
--- a/cloudformation-policy.json
+++ b/cloudformation-policy.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+              "cloudformation:DeleteStack",
+              "cloudformation:DescribeStacks"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
「IAMロール認証を使うように設定されたAWSアカウント」を削除する際に使われる、CloudFormation APIの以下の Actionを許可するためのIAMポリシーを追加します。

- `DeleteStack`
- `DescribeStacks`
