### PR TITLE
新しいSQSトリガーのリリースに伴い不要となった権限を削除

### DIFF
--- a/sqs-policy.json
+++ b/sqs-policy.json
@@ -5,11 +5,9 @@
       "Effect": "Allow",
       "Action": [
         "sqs:AddPermission",
-        "sqs:DeleteMessage",
         "sqs:GetQueueAttributes",
         "sqs:GetQueueUrl",
         "sqs:ListQueues",
-        "sqs:ReceiveMessage",
         "sqs:RemovePermission",
         "sqs:SendMessage"
       ],


### PR DESCRIPTION
新しいSQSトリガーのリリースに伴い不要となった権限を削除しました。