### PR TITLE
cloudformationのIAMポリシーを追加

### DIFF
--- a/cloudformation-policy.json
+++ b/cloudformation-policy.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:DescribeStacks"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
IAMロール方式AWSアカウントの利便性向上のため、"cloudformation:DescribeStacks" のIAMポリシーを追加しました。