### PR TITLE
Add a new policy JSON file for ECS

### DIFF
--- a/ecs-policy.json
+++ b/ecs-policy.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeClusters",
+        "ecs:DescribeTasks",
+        "ecs:ListClusters",
+        "ecs:ListTaskDefinitionFamilies",
+        "ecs:ListTasks",
+        "ecs:RunTask",
+        "ecs:StopTask"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
Added a policy JSON which allows managing ECS resources via Cloud Automator.

- `ecs:DescribeTasks`
- `ecs:DescribeClusters`
- `ecs:ListClusters`
- `ecs:ListTaskDefinitionFamilies`
- `ecs:ListTasks`
- `ecs:RunTask`
- `ecs:StopTas`
