### PR TITLE
Allow iam:PassRole action

### DIFF
--- a/iam-policy.json
+++ b/iam-policy.json
@@ -24,6 +24,7 @@
                 "iam:ListPolicyVersions",
                 "iam:ListRoles",
                 "iam:ListUsers",
+                "iam:PassRole",
                 "iam:SetDefaultPolicyVersion",
                 "iam:UpdateAssumeRolePolicy",
                 "config:DeleteConfigRule",


### PR DESCRIPTION
This rule required by ECS runTask.