### PR TITLE
EBSボリュームが暗号化されている場合にEC2の開始に必要な権限を追加

### DIFF
--- a/kms-policy.json
+++ b/kms-policy.json
@@ -4,9 +4,13 @@
     {
       "Effect": "Allow",
       "Action": [
+        "kms:CreateGrant",
+        "kms:Decrypt",
+        "kms:GenerateDataKeyWithoutPlainText",
         "kms:ListKeys",
         "kms:ListAliases",
-        "kms:DescribeKey"
+        "kms:DescribeKey",
+        "kms:ReEncrypt"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
https://repost.aws/ja/knowledge-center/linux-troubleshoot-automatic-instance-termination